### PR TITLE
Adicionar botão de controle de histórico (navegação

### DIFF
--- a/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
@@ -251,7 +251,12 @@ public class WebviewActivity extends AppCompatActivity {
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                myWebView.goBack();
+                if(myWebView.canGoBack()){
+                    myWebView.goBack();
+                }
+                else{
+                    WebviewActivity.this.onBackPressed();
+                }
             }
         });
     }

--- a/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
@@ -36,6 +36,7 @@ import androidx.core.content.ContextCompat;
 
 import com.datami.smi.SdState;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.io.File;
 import java.io.IOException;
@@ -246,6 +247,13 @@ public class WebviewActivity extends AppCompatActivity {
         } else if (url.equals("https://pt.wikipedia.org/")) {
           checkWikipediaFirstRun();
         }
+        FloatingActionButton fab = findViewById(R.id.fab);
+        fab.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                myWebView.goBack();
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
@@ -70,7 +70,7 @@ public class WebviewActivity extends AppCompatActivity {
     private static final int FILECHOOSER_RESULTCODE = 1;
     private String classrom_tutorial = "Esta aba serve para acessar sua conta do Google Sala de Aula.\n\nSeu email de acesso é composto pelo primeiro nome junto com o código de estudante, acrescido de @estudante.se.df.gov.br\n\nPara saber como obter o primeiro acesso, verifique a aba 'sobre', no link, 'como acessar o Google Sala de Aula'.";
     private String wikipedia_tutorial = "Esta aba serve para acessar a wikipédia.\n\nUtilizando o ícone da lupa é possivel fazer buscas dentro da wikipédia";
-
+    private FloatingActionButton fab;
     private File createImageFile() throws IOException {
         // Create an image file name
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(new Date());
@@ -247,7 +247,7 @@ public class WebviewActivity extends AppCompatActivity {
         } else if (url.equals("https://pt.wikipedia.org/")) {
           checkWikipediaFirstRun();
         }
-        FloatingActionButton fab = findViewById(R.id.fab);
+        fab = findViewById(R.id.fab);
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -486,11 +486,24 @@ public class WebviewActivity extends AppCompatActivity {
             return url;
         }
 
+        public void setBackFloatButtonVisibilty(WebView view){
+            if(view.canGoBack()){
+                fab.setVisibility(View.VISIBLE);
+            }else{
+                fab.setVisibility(View.GONE);
+            }
+        }
+
+        @Override
+        public void onLoadResource(WebView view, String url) {
+            setBackFloatButtonVisibilty(view);
+            super.onLoadResource(view, url);
+        }
+
         @Override
         public boolean shouldOverrideUrlLoading(WebView webView, String urlParameter) {
             Log.d("URL: ", urlParameter);
             String url = this.youtubeProtect(webView, urlParameter);
-
             try {
                 Log.d("URL: ", url);
                 if (url.startsWith("javascript"))

--- a/app/src/main/res/layout/activity_webview.xml
+++ b/app/src/main/res/layout/activity_webview.xml
@@ -14,9 +14,11 @@
         android:layout_alignParentEnd="true"
         android:layout_marginEnd="20dp"
         android:layout_marginBottom="20dp"
+        android:background="#FFFFFF"
         android:clickable="true"
         android:contentDescription="@string/todo"
         android:focusable="true"
+        android:tint="#FFFFFF"
         app:srcCompat="?attr/homeAsUpIndicator" />
 
     <WebView

--- a/app/src/main/res/layout/activity_webview.xml
+++ b/app/src/main/res/layout/activity_webview.xml
@@ -6,11 +6,26 @@
     android:layout_height="match_parent"
     tools:context=".WebviewActivity">
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignBottom="@+id/web_view"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="20dp"
+        android:clickable="true"
+        android:contentDescription="@string/todo"
+        android:focusable="true"
+        app:srcCompat="?attr/homeAsUpIndicator" />
+
     <WebView
         android:id="@+id/web_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/navigation" />
+        android:layout_above="@+id/navigation" >
+
+    </WebView>
 
     <ProgressBar
         android:id="@+id/progressBar1"
@@ -33,5 +48,7 @@
         app:itemIconTint="@drawable/selector"
         app:itemTextColor="@drawable/selector"
         app:labelVisibilityMode="labeled"
-        app:menu="@menu/main_menu" />
+        app:menu="@menu/main_menu" >
+
+    </com.google.android.material.bottomnavigation.BottomNavigationView>
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="http_www_se_df_gov_br"><u>Secretaria da Educação (site)</u></string>
     <string name="tutorial"> Dificuldades para usar o aplicativo? </string>
     <string name="tutorial_btn"> Tutorial interativo </string>
+    <string name="todo">TODO</string>
 </resources>


### PR DESCRIPTION
**Descrição da mudança**  
<!-- Descreva de forma clara e concisa sobre a mudança feita. -->
Foi adicionado um botão flutuante para retornar a página anterior caso isso seja possível. O botão se esconde automaticamente caso não seja possível retornar a página anterior.
**Feature**  
<!-- Marque o checkbox correspondente a mudança. -->
- [x] Correção de bug.
- [x] Adição de nova fucionalidade.
- [ ] Documentação.
- [ ] Outro: <!-- Especifique. -->

**Issue relacionada**  
<!-- Adicionar FIX com as issues relacionadas ao abrir o PR. Ex.: Fix #15 -->
FIX [#13](https://github.com/GCES-Escola-em-Casa-2020-2/wiki/issues/13)

**Screenshots**  
<!-- Se aplicável, adicione imagens da tela para ajudar a explicar a mudança feita. -->
![Captura de Tela 2021-03-23 às 15 29 03](https://user-images.githubusercontent.com/45996980/112199040-8384e700-8bec-11eb-9c50-3fd84b979073.png)

https://user-images.githubusercontent.com/45996980/112199493-fd1cd500-8bec-11eb-947c-41755cf41080.mov


**Informações adicionais**  
<!-- Comente outra informação relevante sobre o seu problema aqui. -->
Ao utilizar o webview do app em alguns momentos o app não responde mais aos toques dentro do navegador e ao pressionar o botão de voltar nada acontece. Para solucionar isso é necessário clicar em outro item na barra de navegação e então retornar a página que estava sendo utilizada. Como solução foi adicionado um botão auxiliar flutuante que permite que o usuário volte até a página anterior sem muitos problemas além de não fechar o app ao realizar tal ação.